### PR TITLE
Fixed issues related to enabling generic math on primitive types

### DIFF
--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -1730,6 +1730,11 @@ BOOL TypeVarTypeDesc::SatisfiesConstraints(SigTypeContext *pTypeContextOfConstra
     }
     CONTRACTL_END;
 
+    // During EEStartup, we cannot safely validate constraints, but we can also be confident that the code doesn't violate them
+    // Just skip validation and declare that the constraints are satisfied.
+    if (g_fEEInit)
+        return TRUE;
+
     IMDInternalImport* pInternalImport = GetModule()->GetMDImport();
     mdGenericParamConstraint tkConstraint;
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -17,6 +17,7 @@
     <ILLinkSharedDirectory>$(MSBuildThisFileDirectory)ILLink\</ILLinkSharedDirectory>
     <Is64Bit Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'x64'">true</Is64Bit>
     <UseMinimalGlobalizationData Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsBrowser)' == 'true'">true</UseMinimalGlobalizationData>
+    <ILLinkTrimAssembly>false</ILLinkTrimAssembly> <!-- TODO! REMOVE BEFORE MERGING TO MASTER Needed as the current linker will delete all explicit static virtual method implementations! -->
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(Is64Bit)' != 'true'">$(DefineConstants);TARGET_32BIT</DefineConstants>

--- a/src/tests/JIT/Math/Generic/GenericMathTests.cs
+++ b/src/tests/JIT/Math/Generic/GenericMathTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace System.GenericMath
 {
     public abstract class GenericMathTests<T>

--- a/src/tests/JIT/Math/Generic/Int32Tests.cs
+++ b/src/tests/JIT/Math/Generic/Int32Tests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+
 namespace System.GenericMath
 {
     public sealed class Int32Tests : GenericMathTests<int>
@@ -15,7 +17,7 @@ namespace System.GenericMath
 
             if (expected != actual)
             {
-                throw new InvalidOperationException($"Expected: {expected}; Actual: {Actual}");
+                throw new InvalidOperationException($"Expected: {expected}; Actual: {actual}");
             }
         }
     }

--- a/src/tests/JIT/Math/Generic/Program.cs
+++ b/src/tests/JIT/Math/Generic/Program.cs
@@ -22,8 +22,9 @@ namespace System.GenericMath
             {
                 action();
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 return -1;
             }
 


### PR DESCRIPTION
- Disable constraint checking during EEInit
- Disable il linker running on CoreLib
- Fixup generic math tests to actually build